### PR TITLE
Implement adjudication workflow

### DIFF
--- a/public/adjudication.html
+++ b/public/adjudication.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Adjudication</title>
+  <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-page="adjudicate">
+  <div class="container">
+    <h1>Adjudication</h1>
+    <div id="status">Loading…</div>
+    <div id="requests"></div>
+  </div>
+  <script type="module" src="/js/main.js" defer></script>
+</body>
+</html>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -5,8 +5,9 @@ import { past } from './pages/past.js';
 import { instructions } from './pages/instructions.js';
 import { admin } from './pages/admin.js';
 import { status } from './pages/status.js';
+import { adjudicate } from './pages/adjudicate.js';
 
-const Pages = { login, select, annotate, past, instructions, admin, status };
+const Pages = { login, select, annotate, past, instructions, admin, status, adjudicate };
 
 document.addEventListener('DOMContentLoaded', () => {
   const page = document.body.dataset.page;

--- a/public/js/pages/adjudicate.js
+++ b/public/js/pages/adjudicate.js
@@ -1,0 +1,53 @@
+import { Common } from '../common/common.js';
+
+export const adjudicate = {
+  passcode: null,
+  async init() {
+    Common.initNavbar();
+    this.passcode = prompt('Enter adjudication passcode:');
+    if (!this.passcode) {
+      document.getElementById('status').textContent = 'Passcode required.';
+      return;
+    }
+    await this.load();
+  },
+
+  async load() {
+    const container = document.getElementById('requests');
+    const status    = document.getElementById('status');
+    status.textContent = 'Loading…';
+    const resp = await fetch(`/adjudications?code=${encodeURIComponent(this.passcode)}`);
+    if (!resp.ok) { status.textContent = 'Invalid passcode.'; return; }
+    const list = await resp.json();
+    container.innerHTML = '';
+    if (!list.length) { status.textContent = 'No pending requests.'; return; }
+    status.textContent = '';
+    for (const r of list) {
+      const card = document.createElement('div');
+      card.className = 'answer-card';
+      card.innerHTML = `
+        <p><strong>User:</strong> ${r.pid}</p>
+        <p><strong>Dataset:</strong> ${r.dataset}</p>
+        <p><strong>Q:</strong> ${r.question}</p>
+        <p><strong>User Answer:</strong> ${r.answer}</p>
+        ${r.label ? `<p><strong>Label:</strong> ${r.label}</p>` : ''}
+        <div style="margin-top:.5rem;">
+          <button class="yesBtn">User Correct</button>
+          <button class="noBtn">User Incorrect</button>
+        </div>
+      `;
+      card.querySelector('.yesBtn').addEventListener('click', () => this.judge(r, true));
+      card.querySelector('.noBtn').addEventListener('click', () => this.judge(r, false));
+      container.appendChild(card);
+    }
+  },
+
+  async judge(rec, correct) {
+    await fetch(`/adjudicate_result?code=${encodeURIComponent(this.passcode)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pid: rec.pid, dataset: rec.dataset, uid: rec.uid, correct })
+    });
+    this.load();
+  }
+};

--- a/public/js/pages/past.js
+++ b/public/js/pages/past.js
@@ -172,6 +172,22 @@ export const past = {
           </div>
         `;
 
+        if (r.llm_eval === 'Incorrect') {
+          const adjBtn = document.createElement('button');
+          adjBtn.textContent = 'Request adjudication';
+          adjBtn.style.marginLeft = '0.5rem';
+          card.querySelector('div').appendChild(adjBtn);
+          adjBtn.addEventListener('click', async () => {
+            adjBtn.disabled = true;
+            adjBtn.textContent = 'Requested';
+            await fetch('/request_adjudication', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ pid: Common.pid(), dataset: Common.ds(), uid: r.uid })
+            });
+          });
+        }
+
         /* -------- grab elements -------- */
         const ansIn   = card.querySelector('input[type=text]');
         // const diffIn  = card.querySelector('input[type=number]');


### PR DESCRIPTION
## Summary
- add server-side endpoints for adjudication requests
- allow annotators to request adjudication from Past Answers
- add adjudication page behind a passcode
- register adjudication page in JS router

## Testing
- `node --check server.js`
- `node --check public/js/pages/adjudicate.js`

------
https://chatgpt.com/codex/tasks/task_e_686146430cc48333ab60b28a98826daa